### PR TITLE
disable perfsprint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -55,6 +55,7 @@ linters:
     - varcheck
     - structcheck
     - protogetter
+    - perfsprint
 
 linters-settings:
   goheader:


### PR DESCRIPTION
Disable perfsprint, this will create errors for imported external packages. 